### PR TITLE
Fix unittest by providing negative expireAfterWrite value

### DIFF
--- a/tests/test_single_value_cache.py
+++ b/tests/test_single_value_cache.py
@@ -20,7 +20,7 @@ class TestSingleValueCache(unittest.TestCase):
         self.assertEqual(svc.get(), 1)
 
     def test_supplier_method_is_used_after_value_expired(self):
-        svc = SingleValueCache(0, self.counter)
+        svc = SingleValueCache(-100, self.counter)
 
         self.assertEqual(svc.get(), 1)
         self.assertEqual(svc.get(), 2)


### PR DESCRIPTION
It appears the test is run to quick on Win10 with Python 3.8.1 for the
existing 0 value