### PR TITLE
avoid installation of 'test' package at top level

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/vanbalken/arris-tg2492lg",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['tests']),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
fixes https://github.com/vanbalken/arris-tg2492lg/issues/16
fixes https://git.edevau.net/onkelbeh/HomeAssistantRepository/issues/181